### PR TITLE
fix: update artifact upload action

### DIFF
--- a/.github/workflows/pages-deployment.yml
+++ b/.github/workflows/pages-deployment.yml
@@ -36,7 +36,7 @@ jobs:
         run: npm run build
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-artifact@v4
         with:
           name: nextjs-build
           path: dist


### PR DESCRIPTION
This pull request makes a small update to the deployment workflow by switching to a more general artifact upload action.

* The workflow now uses `actions/upload-artifact@v4` instead of `actions/upload-pages-artifact@v4` for uploading the build output in `.github/workflows/pages-deployment.yml`.